### PR TITLE
Add set for user preferences

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -26,7 +26,7 @@ func Init() {
 	flag.StringVar(&url, "url", "", "--url=channel_curl Set the radio URL")
 	flag.StringVar(&setKey, "setKey", "", "--setKey=key The key to set for a custom user preference option. Used with setValue")
 	flag.StringVar(&setValue, "setValue", "", "--setValue=value The value to set for a custom user preference option. Used with setKey")
-	flag.StringVar(&owner, "setowner", "", "--setowner=owner Set the listed owner for the radio")
+	flag.StringVar(&owner, "setOwner", "", "--setowner=owner Set the listed owner for the radio")
 	flag.Int64Var(&to, "to", 0, "--to=destination Node to receive text (Used with sendtext)")
 	recv := flag.Bool("recv", false, "Wait for new messages")
 	infoPtr := flag.Bool("info", false, "Display radio information")

--- a/cli.go
+++ b/cli.go
@@ -16,12 +16,16 @@ func Init() {
 	var port string
 	var message string
 	var owner string
+	var setKey string
+	var setValue string
 	var url string
 	var to int64
 
 	flag.StringVar(&port, "port", "", "--port=port The serial port for the radio (Required)")
 	flag.StringVar(&message, "text", "", "--text=message Send a text message")
 	flag.StringVar(&url, "url", "", "--url=channel_curl Set the radio URL")
+	flag.StringVar(&setKey, "setKey", "", "--setKey=key The key to set for a custom user preference option. Used with setValue")
+	flag.StringVar(&setValue, "setValue", "", "--setValue=value The value to set for a custom user preference option. Used with setKey")
 	flag.StringVar(&owner, "setowner", "", "--setowner=owner Set the listed owner for the radio")
 	flag.Int64Var(&to, "to", 0, "--to=destination Node to receive text (Used with sendtext)")
 	recv := flag.Bool("recv", false, "Wait for new messages")
@@ -38,7 +42,7 @@ func Init() {
 		fmt.Printf("\n")
 		fmt.Printf("COMMANDS\n")
 		fmt.Printf("\n")
-		order := []string{"port", "info", "recv", "longSlow", "shortFast", "text", "setowner"}
+		order := []string{"port", "info", "recv", "longSlow", "shortFast", "text", "setowner", "setKey", "setValue"}
 		for _, name := range order {
 			flag := flagSet.Lookup(name)
 			fmt.Printf("--%-15s", flag.Name)
@@ -54,7 +58,7 @@ func Init() {
 	}
 
 	radio := Radio{}
-	if len(message) > 0 || *infoPtr || *recv || len(owner) > 0 || len(url) > 0 || *longslowPtr || *shortFast {
+	if len(message) > 0 || *infoPtr || *recv || len(owner) > 0 || len(url) > 0 || *longslowPtr || *shortFast || len(setKey) > 0 || len(setValue) > 0 {
 		radio.Init(port)
 		defer radio.Close()
 	}
@@ -113,6 +117,15 @@ func Init() {
 			fmt.Printf("ERROR: %s\n", err)
 		} else {
 			fmt.Printf("Set owner successful\n")
+		}
+	}
+
+	if setValue != "" && setKey != "" {
+		err := radio.SetUserPreferences(setKey, setValue)
+		if err != nil {
+			fmt.Printf("ERROR: %s\n", err)
+		} else {
+			fmt.Printf("Set user preferences successful\n")
 		}
 	}
 

--- a/radio.go
+++ b/radio.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"log"
 	"math/rand"
+	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -345,6 +347,65 @@ func (r *Radio) SetChannel(channel int) error {
 
 	return nil
 
+}
+
+// SetUserPreferences allows an freeform setting of values in the RadioConfig_UserPreferences struct
+func (r *Radio) SetUserPreferences(key string, value string) error {
+
+	responses, err := r.GetRadioInfo()
+
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	var currentRadioInfo *pb.FromRadio_Radio
+
+	for _, response := range responses {
+
+		if radioInfo, ok := response.GetPayloadVariant().(*pb.FromRadio_Radio); ok {
+
+			currentRadioInfo = radioInfo
+
+		}
+
+	}
+
+	rPref := reflect.ValueOf(currentRadioInfo.Radio.Preferences)
+
+	rPref = rPref.Elem()
+
+	fv := rPref.FieldByName(key)
+	if !fv.IsValid() {
+		return errors.New("Unknown Field")
+	}
+
+	// Field must be exported
+	if !fv.CanSet() {
+		return errors.New("Unknown Field")
+	}
+
+	boolValue, err := strconv.ParseBool(value)
+	fv.SetBool(boolValue)
+
+	prefSet := pb.ToRadio{
+		PayloadVariant: &pb.ToRadio_SetRadio{
+			SetRadio: &pb.RadioConfig{
+				Preferences:     currentRadioInfo.Radio.Preferences,
+				ChannelSettings: currentRadioInfo.Radio.ChannelSettings,
+			},
+		},
+	}
+
+	out, err := proto.Marshal(&prefSet)
+	if err != nil {
+		return err
+	}
+
+	if err := r.sendPacket(out); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Close closes the serial port. Added so users can defer the close after opening

--- a/radio.go
+++ b/radio.go
@@ -379,13 +379,28 @@ func (r *Radio) SetUserPreferences(key string, value string) error {
 		return errors.New("Unknown Field")
 	}
 
-	// Field must be exported
 	if !fv.CanSet() {
 		return errors.New("Unknown Field")
 	}
 
-	boolValue, err := strconv.ParseBool(value)
-	fv.SetBool(boolValue)
+	vType := fv.Type()
+
+	// The acceptable values that can be set from the command line are uint32 and bool, so only check for those
+	switch vType.Kind() {
+	case reflect.Bool:
+		boolValue, err := strconv.ParseBool(value)
+		if err != nil {
+			return err
+		}
+		fv.SetBool(boolValue)
+		break
+	case reflect.Uint32:
+		uintValue, err := strconv.ParseUint(value, 10, 32)
+		if err != nil {
+			return err
+		}
+		fv.SetUint(uintValue)
+	}
 
 	prefSet := pb.ToRadio{
 		PayloadVariant: &pb.ToRadio_SetRadio{


### PR DESCRIPTION
This PR adds the `-setKey` and `-setValue` CLI options to set unspecified options in the `UserPreferences` object for the Radio. Right now only Bool and uint32 values can be passed, but based on the examples in the Python library this should work for CLI usage.