### PR TITLE
Add the --json flag to message recv

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -113,6 +113,11 @@ func Init() {
 								Value:   0,
 							},
 							&cli.BoolFlag{
+								Name:     "json",
+								Usage:    "Output messages in JSON with a newline between each message",
+								Required: false,
+							},
+							&cli.BoolFlag{
 								Name:     "exit",
 								Aliases:  []string{"e"},
 								Usage:    "Exit after receiving a message from the mesh",


### PR DESCRIPTION
Adds the `--json` flag to `message recv` so messages can be parsed from a JSON format. The catch with this is that the way `recv` works doesn't make it so messages can be nicely packaged up in a JSON array to be parsed through later. To help provide some automation each JSON message will have a newline character (`\n`) after it is printed. This should make it possible to build automation off of the messages as they come in in their written to a file

Example output from `message recv --json`
```
> go run . --port /dev/cu.usbserial-0200674E message recv --json 
{"from":476494060,"to":862621917,"portnum": "TEXT_MESSAGE_APP","channel":0,"Payload": "test Sun Jan 12 19:21:56 2025"}
{"from":476494060,"to":862621917,"portnum": "TEXT_MESSAGE_APP","channel":0,"Payload": "test Sun Jan 12 19:22:01 2025"}
```